### PR TITLE
Capture additional user and group events

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| target\_arn | The ARN of a target (usually an SNS topic) that should be notified when certain IAM/SSO user or group events occur (e.g. arn:aws:sns:us-east-1:012345678901:my-sns-topic). | `string` | n/a | yes |
+| target\_arn | The ARN of a target (usually an SNS topic) that should be notified when someone creates or deletes an IAM or SSO user, adds or removes a user from a group, or creates or deletes a group (e.g. arn:aws:sns:us-east-1:012345678901:my-sns-topic). | `string` | n/a | yes |
 
 ## Outputs ##
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| target\_arn | The ARN of a target (usually an SNS topic) that should be notified when an IAM or SSO user is created (e.g. arn:aws:sns:us-east-1:012345678901:my-sns-topic). | `string` | n/a | yes |
+| target\_arn | The ARN of a target (usually an SNS topic) that should be notified when certain IAM/SSO user or group events occur (e.g. arn:aws:sns:us-east-1:012345678901:my-sns-topic). | `string` | n/a | yes |
 
 ## Outputs ##
 

--- a/event.tf
+++ b/event.tf
@@ -1,22 +1,29 @@
 # ------------------------------------------------------------------------------
-# Create an EventBridge event rule for when an IAM or SSO user is
-# created.  Connect the event rule to an appropriate SNS topic so that the
+# Create an EventBridge event rule for when various IAM or SSO user and group
+# events occur.  Connect the event rule to an appropriate SNS topic so that the
 # correct folks are notified.
 # ------------------------------------------------------------------------------
 
 resource "aws_cloudwatch_event_rule" "this" {
-  description = "Capture each time someone creates an IAM or SSO user."
+  description = "Capture each time someone creates or deletes an IAM or SSO user, adds or removes a user from a group, or creates or deletes a group."
   event_pattern = jsonencode({
     detail-type = ["AWS API Call via CloudTrail"]
     detail = {
-      eventName = ["CreateUser"]
+      eventName = [
+        "AddUserToGroup",
+        "CreateGroup",
+        "CreateUser",
+        "DeleteGroup",
+        "DeleteUser",
+        "RemoveUserFromGroup",
+      ]
       eventSource = [
         "iam.amazonaws.com",
         "sso-directory.amazonaws.com",
       ],
     }
   })
-  name = "capture-create-user"
+  name = "capture-user-group-events"
 }
 
 resource "aws_cloudwatch_event_target" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -6,5 +6,5 @@
 
 variable "target_arn" {
   type        = string
-  description = "The ARN of a target (usually an SNS topic) that should be notified when certain IAM/SSO user or group events occur (e.g. arn:aws:sns:us-east-1:012345678901:my-sns-topic)."
+  description = "The ARN of a target (usually an SNS topic) that should be notified when someone creates or deletes an IAM or SSO user, adds or removes a user from a group, or creates or deletes a group (e.g. arn:aws:sns:us-east-1:012345678901:my-sns-topic)."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,5 +6,5 @@
 
 variable "target_arn" {
   type        = string
-  description = "The ARN of a target (usually an SNS topic) that should be notified when an IAM or SSO user is created (e.g. arn:aws:sns:us-east-1:012345678901:my-sns-topic)."
+  description = "The ARN of a target (usually an SNS topic) that should be notified when certain IAM/SSO user or group events occur (e.g. arn:aws:sns:us-east-1:012345678901:my-sns-topic)."
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds some additional events to the event rule that triggers an alert.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Our security team has requested that these additional events (`"AddUserToGroup", "CreateGroup", "DeleteGroup", "DeleteUser", "RemoveUserFromGroup"`) also trigger notification alerts.

Note that with this change, the current name of this module (`new-user-alert-tf-module`) is no longer sufficient.  I will be renaming this repo shortly and updating all references to it.

Resolves #24.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested this by pulling in this branch's version of the module and successfully applying it in the `cool-accounts/users` Terraform.  After applying, I visually confirmed that the new EventBridge rule contained all of the events added in this PR and was named appropriately.
 
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Rename this repo from `new-user-alert-tf-module` to `user-group-mod-alert-tf-module`.
- [x] Update [all references to this repo](https://github.com/search?q=org%3Acisagov+new-user-alert-tf-module&type=code) accordingly:
  - [x] https://github.com/cisagov/user-group-mod-alert-tf-module/pull/26
  - [x] https://github.com/cisagov/cool-accounts/pull/140
  - [x] https://github.com/cisagov/cool-accounts-userservices/pull/37
- [x] Re-apply all Terraform that was updated above, in order to deploy the code changes from this PR.
