### PR TITLE
Update references and content after repo name change

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ all of which should be in this repository.
 
 If you want to report a bug or request a new feature, the most direct
 method is to [create an
-issue](https://github.com/cisagov/new-user-alert-tf-module/issues) in this
+issue](https://github.com/cisagov/user-group-mod-alert-tf-module/issues) in this
 repository.  We recommend that you first search through existing
 issues (both open and closed) to check if your particular issue has
 already been reported.  If it has then you might want to add a comment
@@ -25,7 +25,7 @@ one.
 ## Pull requests ##
 
 If you choose to [submit a pull
-request](https://github.com/cisagov/new-user-alert-tf-module/pulls), you
+request](https://github.com/cisagov/user-group-mod-alert-tf-module/pulls), you
 will notice that our continuous integration (CI) system runs a fairly
 extensive set of linters and syntax checkers.  Your pull request may
 fail these checks, and that's OK.  If you want you can stop there and
@@ -135,9 +135,9 @@ can create and configure the Python virtual environment with these
 commands:
 
 ```console
-cd new-user-alert-tf-module
-pyenv virtualenv <python_version_to_use> new-user-alert-tf-module
-pyenv local new-user-alert-tf-module
+cd user-group-mod-alert-tf-module
+pyenv virtualenv <python_version_to_use> user-group-mod-alert-tf-module
+pyenv local user-group-mod-alert-tf-module
 pip install --requirement requirements-dev.txt
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# new-user-alert-tf-module #
+# user-group-mod-alert-tf-module #
 
-[![GitHub Build Status](https://github.com/cisagov/new-user-alert-tf-module/workflows/build/badge.svg)](https://github.com/cisagov/new-user-alert-tf-module/actions)
+[![GitHub Build Status](https://github.com/cisagov/user-group-mod-alert-tf-module/workflows/build/badge.svg)](https://github.com/cisagov/user-group-mod-alert-tf-module/actions)
 
 A Terraform module for creating an EventBridge event that triggers
 whenever a new IAM or SSO user is created.
@@ -9,7 +9,7 @@ whenever a new IAM or SSO user is created.
 
 ```hcl
 module "example" {
-  source = "github.com/cisagov/new-user-alert-tf-module"
+  source = "github.com/cisagov/user-group-mod-alert-tf-module"
 
   target_arn = "arn:aws:sns:us-east-1:012345678901:my-sns-topic"
 }
@@ -17,7 +17,7 @@ module "example" {
 
 ## Examples ##
 
-- [Basic usage](https://github.com/cisagov/new-user-alert-tf-module/tree/develop/examples/basic_usage)
+- [Basic usage](https://github.com/cisagov/user-group-mod-alert-tf-module/tree/develop/examples/basic_usage)
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements ##

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [![GitHub Build Status](https://github.com/cisagov/user-group-mod-alert-tf-module/workflows/build/badge.svg)](https://github.com/cisagov/user-group-mod-alert-tf-module/actions)
 
-A Terraform module for creating an EventBridge event that triggers
-whenever a new IAM or SSO user is created.
+A Terraform module for creating an EventBridge event that triggers whenever a
+new IAM or SSO user is created or deleted, a user is added or removed from a
+group, or a group is created or deleted.
 
 ## Usage ##
 

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -1,4 +1,8 @@
-# Notify an SNS Topic When a New IAM or SSO User is Created #
+# Notify an SNS Topic When Certain IAM or SSO User or Group Events Occur #
+
+Specifically, the SNS topic is notified when a new IAM or SSO user is created
+or deleted, a user is added or removed from a group, or a group is created or
+deleted.
 
 ## Usage ##
 
@@ -45,6 +49,6 @@ Note that this example may create resources which cost money. Run
 
 | Name | Description |
 |------|-------------|
-| rule | The EventBridge event rule that will be triggered when a new IAM or SSO user is created. |
+| rule | The EventBridge event rule that will be triggered when a new IAM or SSO user is created or deleted, a user is added or removed from a group, or a group is created or deleted. |
 | target | The EventBridge event target for the rule. |
-| topic | The SNS topic that will be notified when a new IAM or SSO user is created. |
+| topic | The SNS topic that will be notified when a new IAM or SSO user is created or deleted, a user is added or removed from a group, or a group is created or deleted. |


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates all references in this repo from the old name (`new-user-alert-tf-module`) to the new name (`user-group-mod-alert-tf-module`).  This PR also includes some documentation changes to reflect the new functionality added in #25.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The changes in #25 necessitated a name change for this repo.  This PR is a direct result of the repo name change.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

All automated tests pass and all Markdown was visually inspected.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
